### PR TITLE
Fix redundant data loading on CEDI pages

### DIFF
--- a/BRBKApp/Views/CediOrdenTrabajoPage.xaml.cs
+++ b/BRBKApp/Views/CediOrdenTrabajoPage.xaml.cs
@@ -12,7 +12,6 @@ namespace BRBKApp.Views
         {
             InitializeComponent();
             _viewModel = new CediOrdenTrabajoViewModel();
-            _viewModel.LoadOrdenes().ConfigureAwait(true);
             BindingContext = _viewModel;
         }
         protected override void OnAppearing()

--- a/BRBKApp/Views/CediTarjaPage.xaml.cs
+++ b/BRBKApp/Views/CediTarjaPage.xaml.cs
@@ -12,7 +12,6 @@ namespace BRBKApp.Views
         {
             InitializeComponent();
             _viewModel = new CediTarjaViewModel();
-            _viewModel.LoadTarja().ConfigureAwait(true);
             BindingContext = _viewModel;
         }
         protected override void OnAppearing()


### PR DESCRIPTION
## Summary
- remove page-level calls to `LoadOrdenes` and `LoadTarja`
- rely on the view-model constructors to load data

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package has no installation candidate)*
- `xbuild BRBKApp.sln` *(fails: command not found)*
- `msbuild BRBKApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d93199f948330b0ebdcb12982702d