### PR TITLE
Fix long vs int type mismatch

### DIFF
--- a/BRBKApp/Models/AppModelNovedadDetalleTarja.cs
+++ b/BRBKApp/Models/AppModelNovedadDetalleTarja.cs
@@ -6,7 +6,7 @@ namespace BRBKApp.Models
 {
     public class AppModelNovedadDetalleTarja
     {
-        public int DetalleTarjaID { get; set; }
+        public long DetalleTarjaID { get; set; }
         public string Descripcion { get; set; }
     }
 }

--- a/BRBKApp/ViewModels/VHSNovedadDetalleTarjaViewModel .cs
+++ b/BRBKApp/ViewModels/VHSNovedadDetalleTarjaViewModel .cs
@@ -37,7 +37,7 @@ namespace BRBKApp.ViewModels
             set => SetProperty(ref descripcionDetalle, value);
         }
 
-        public int DetalleTarjaID { get; set; }
+        public long DetalleTarjaID { get; set; }
         public string NumeroTarja { get; set; }
 
         public Command SaveCommand { get; }


### PR DESCRIPTION
## Summary
- ensure DetalleTarjaID uses long instead of int

## Testing
- `dotnet build BRBKApp.sln -c Release` *(fails: dotnet not installed)*
- `msbuild BRBKApp.sln /t:Build /p:Configuration=Release` *(fails: msbuild not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686e9c76de2883308ac9de734fbc5ce9