### PR TITLE
Fix missing ApiModels namespace

### DIFF
--- a/BRBKApp/AppShell.xaml.cs
+++ b/BRBKApp/AppShell.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using BRBKApp.ViewModels;
 using BRBKApp.Views;
+using ApiModels.AppModels;
 using System;
 using System.Collections.Generic;
 using System.Windows.Input;

--- a/BRBKApp/Views/CediOrdenTrabajoPage.xaml.cs
+++ b/BRBKApp/Views/CediOrdenTrabajoPage.xaml.cs
@@ -1,4 +1,5 @@
 using BRBKApp.ViewModels;
+using ApiModels.AppModels;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 

--- a/BRBKApp/Views/CediTarjaDetallePage.xaml.cs
+++ b/BRBKApp/Views/CediTarjaDetallePage.xaml.cs
@@ -1,5 +1,6 @@
 using BRBKApp.Services;
 using BRBKApp.ViewModels;
+using ApiModels.AppModels;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 


### PR DESCRIPTION
## Summary
- add missing `ApiModels.AppModels` `using` directives for Cedi pages

## Testing
- `dotnet build BRBKApp.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eafab42a88330bfcf2aad7f879db3