### PR TITLE
Fix missing SqlClient package

### DIFF
--- a/ApiDatos/ApiDatos.csproj
+++ b/ApiDatos/ApiDatos.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />

--- a/ApiModels/ApiModels.csproj
+++ b/ApiModels/ApiModels.csproj
@@ -1,10 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="sqlite-net-pcl" Version="1.7.335" />
     <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.0.3" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup></Project>

--- a/BRBKApp/BRBKApp.csproj
+++ b/BRBKApp/BRBKApp.csproj
@@ -10,6 +10,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ViewModel/ViewModel.csproj
+++ b/ViewModel/ViewModel.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup></Project>


### PR DESCRIPTION
## Summary
- update netstandard projects to avoid duplicate assembly attributes
- add System.Data.SqlClient to ApiModels

## Testing
- `dotnet build BRBKApp.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec7b938308330bb13baf50def1e1c