### PR TITLE
Remove unused SqlClient imports

### DIFF
--- a/ApiModels/AppModels/BAN_Catalogo_Estado.cs
+++ b/ApiModels/AppModels/BAN_Catalogo_Estado.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;

--- a/ApiModels/AppModels/BAN_Catalogo_Modalidad.cs
+++ b/ApiModels/AppModels/BAN_Catalogo_Modalidad.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 
 namespace ApiModels.AppModels
 {

--- a/ApiModels/AppModels/BAN_Catalogo_TipoMovimiento.cs
+++ b/ApiModels/AppModels/BAN_Catalogo_TipoMovimiento.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;

--- a/ApiModels/AppModels/BAN_Consulta_Combo.cs
+++ b/ApiModels/AppModels/BAN_Consulta_Combo.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 
 namespace ApiModels.AppModels
 {

--- a/ApiModels/AppModels/Items.cs
+++ b/ApiModels/AppModels/Items.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 
 namespace ApiModels.AppModels
 {

--- a/ApiModels/AppModels/carrier.cs
+++ b/ApiModels/AppModels/carrier.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 
 namespace ApiModels.AppModels
 {

--- a/ApiModels/AppModels/condicion.cs
+++ b/ApiModels/AppModels/condicion.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 
 namespace ApiModels.AppModels
 {

--- a/ApiModels/AppModels/configuracionAlerta.cs
+++ b/ApiModels/AppModels/configuracionAlerta.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;

--- a/ApiModels/AppModels/estado.cs
+++ b/ApiModels/AppModels/estado.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;

--- a/ApiModels/AppModels/grupoMail.cs
+++ b/ApiModels/AppModels/grupoMail.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 
 namespace ApiModels.AppModels
 {

--- a/ApiModels/AppModels/grupos.cs
+++ b/ApiModels/AppModels/grupos.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 
 namespace ApiModels.AppModels
 {

--- a/ApiModels/AppModels/imo.cs
+++ b/ApiModels/AppModels/imo.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;

--- a/ApiModels/AppModels/lineaNaviera.cs
+++ b/ApiModels/AppModels/lineaNaviera.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 
 namespace ApiModels.AppModels
 {
@@ -12,5 +11,4 @@ namespace ApiModels.AppModels
         public string id { get; set; }
         public string nombre { get; set; }
         #endregion
-    }
-}
+    }}

--- a/ApiModels/AppModels/maniobra.cs
+++ b/ApiModels/AppModels/maniobra.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 
 namespace ApiModels.AppModels
 {

--- a/ApiModels/AppModels/opcionesRoles.cs
+++ b/ApiModels/AppModels/opcionesRoles.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 
 namespace ApiModels.AppModels
 {

--- a/ApiModels/AppModels/parametros.cs
+++ b/ApiModels/AppModels/parametros.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 
 namespace ApiModels.AppModels
 {

--- a/ApiModels/AppModels/productos.cs
+++ b/ApiModels/AppModels/productos.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 
 namespace ApiModels.AppModels
 {

--- a/ApiModels/AppModels/sealValidation.cs
+++ b/ApiModels/AppModels/sealValidation.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;

--- a/ApiModels/AppModels/servicios.cs
+++ b/ApiModels/AppModels/servicios.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 
 namespace ApiModels.AppModels
 {

--- a/ApiModels/AppModels/tarjaCab.cs
+++ b/ApiModels/AppModels/tarjaCab.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;

--- a/ApiModels/AppModels/ubicacion.cs
+++ b/ApiModels/AppModels/ubicacion.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 
 namespace ApiModels.AppModels
 {

--- a/ApiModels/AppModels/workPosition.cs
+++ b/ApiModels/AppModels/workPosition.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;


### PR DESCRIPTION
## Summary
- tidy AppModels by removing unused `System.Data.SqlClient` directives

## Testing
- `dotnet restore BRBKApp.sln`
- `dotnet build BRBKApp.sln` *(fails: missing Xamarin and .NET Framework tooling)*

------
https://chatgpt.com/codex/tasks/task_e_686ed3a0ab648330be69a80512e731f6