### PR TITLE
Fix base address for tarja details

### DIFF
--- a/ApiDatos/Datos.cs
+++ b/ApiDatos/Datos.cs
@@ -4475,7 +4475,7 @@ namespace ApiDatos
             {
                 using (var client = new HttpClient(handler, false))
                 {
-                    client.BaseAddress = new Uri("http://localhost:4346/"); // Ajustar para producción
+                    client.BaseAddress = new Uri(Baseurl);
                     client.DefaultRequestHeaders.Clear();
                     client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
@@ -4523,7 +4523,7 @@ namespace ApiDatos
             {
                 using (var client = new HttpClient(handler, false))
                 {
-                    client.BaseAddress = new Uri("http://localhost:4346/");
+                    client.BaseAddress = new Uri(Baseurl);
                     client.DefaultRequestHeaders.Clear();
                     client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 


### PR DESCRIPTION
## Summary
- correct tarja detail HTTP client base URL to use the configured API host

## Testing
- `dotnet build ApiDatos/ApiDatos.csproj` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6870055a59fc8330ba443263988002b0