### PR TITLE
Fix MSBuild item Include

### DIFF
--- a/BRBKApp/BRBKApp.csproj
+++ b/BRBKApp/BRBKApp.csproj
@@ -152,7 +152,7 @@
       <DependentUpon>CediTarjaConsultaDetail.xaml</DependentUpon>
     </Compile>
 
-    <Compile Update="Views\CediVehiculosDespachoPage.xaml.cs">
+    <Compile Include="Views\CediVehiculosDespachoPage.xaml.cs">
       <DependentUpon>CediVehiculosDespachoPage.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
@@ -268,7 +268,7 @@
     <EmbeddedResource Update="Views\CediTarjaConsultaDetail.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
-    <EmbeddedResource Update="Views\CediVehiculosDespachoPage.xaml">
+    <EmbeddedResource Include="Views\CediVehiculosDespachoPage.xaml">
 <EmbeddedResource Update="Views/CediNovedadDetalleTarjaPage.xaml">
   <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
 </EmbeddedResource>


### PR DESCRIPTION
## Summary
- update csproj to use `Include` for `CediVehiculosDespachoPage` items

## Testing
- `dotnet build BRBKApp.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870f785a3048330aa2ea9d772129be8