### PR TITLE
Move evidencia capture logic to CEDI module

### DIFF
--- a/ApiDatos/Datos.cs
+++ b/ApiDatos/Datos.cs
@@ -5107,7 +5107,7 @@ namespace ApiDatos
             return respuesta;
         }
 
-        public async Task<RespuestaViewModel<long>> RegistraCediEvidenciaEntregaAsync(ParametroVHSCrearEvidenciaEntrega parametro)
+        public async Task<RespuestaViewModel<long>> RegistraCediEvidenciaEntregaAsync(ParametroCediCrearEvidenciaEntrega parametro)
         {
             HttpClientHandler handler = new HttpClientHandler();
             RespuestaViewModel<long> respuesta = new RespuestaViewModel<long>();

--- a/ApiModels/Parametros/ParametroCediCrearEvidenciaEntrega.cs
+++ b/ApiModels/Parametros/ParametroCediCrearEvidenciaEntrega.cs
@@ -1,0 +1,13 @@
+using ApiModels.AppModels;
+using System.Collections.Generic;
+
+namespace ApiModels.Parametros
+{
+    public class ParametroCediCrearEvidenciaEntrega
+    {
+        public long VehiculoDespachadoID { get; set; }
+        public string Observacion { get; set; }
+        public string Usuario { get; set; }
+        public List<CediEvidenciaEntregaFoto> Fotos { get; set; }
+    }
+}

--- a/BRBKApp/BRBKApp.csproj
+++ b/BRBKApp/BRBKApp.csproj
@@ -155,6 +155,9 @@
     <Compile Include="Views\CediVehiculosDespachoPage.xaml.cs">
       <DependentUpon>CediVehiculosDespachoPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\CediAgregarEvidenciaEntrega.xaml.cs">
+      <DependentUpon>CediAgregarEvidenciaEntrega.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>
@@ -269,10 +272,12 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Views\CediVehiculosDespachoPage.xaml">
-<EmbeddedResource Update="Views/CediNovedadDetalleTarjaPage.xaml">
-  <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-</EmbeddedResource>
-
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Views\CediAgregarEvidenciaEntrega.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Views/CediNovedadDetalleTarjaPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/BRBKApp/DA/ServiceCedi.cs
+++ b/BRBKApp/DA/ServiceCedi.cs
@@ -83,6 +83,27 @@ namespace BRBKApp.DA
             return await datos.GetCediVehiculosDespachoAsync(paseId);
         }
 
+        public static async Task<RespuestaViewModel<long>> RegistraEvidenciaEntrega(ParametroCediCrearEvidenciaEntrega parametro)
+        {
+            Datos datos = new Datos();
+            RespuestaViewModel<long> response = new RespuestaViewModel<long>();
+            try
+            {
+                response = await datos.RegistraCediEvidenciaEntregaAsync(parametro);
+            }
+            catch (Exception ex)
+            {
+                response.Resultado = new ResultadoViewModel
+                {
+                    Respuesta = false,
+                    Titulo = "Error",
+                    TipoMensaje = Enumerados.TipoMensaje.Error,
+                    Mensajes = new List<string> { ex.Message }
+                };
+            }
+            return response;
+        }
+
         public static async Task<RespuestaViewModel<int>> RegistrarCediNovedadDetalleTarja(ParametroRegistrarNovedadDetalleTarja request)
         {
             RespuestaViewModel<int> returnValue = new RespuestaViewModel<int>();

--- a/BRBKApp/ViewModels/CediAgregarEvidenciaViewModel.cs
+++ b/BRBKApp/ViewModels/CediAgregarEvidenciaViewModel.cs
@@ -1,0 +1,244 @@
+﻿using Acr.UserDialogs;
+using ApiModels.Parametros;
+using ApiModels.AppModels;
+using BRBKApp.DA;
+using Plugin.Media;
+using Plugin.Media.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Xamarin.Forms;
+
+namespace BRBKApp.ViewModels
+{
+    public class CediAgregarEvidenciaViewModel : BaseViewModel
+    {
+        private readonly long _vehiculoDespachadoId;
+
+        public string Observacion { get; set; }
+
+        public Command TapCommand { get; }
+        public Command GrabarCommand { get; }
+        public Command CerrarCommand { get; }
+
+        // Fotos en bytes
+        public byte[] ArrayFoto0;
+        public byte[] ArrayFoto1;
+        public byte[] ArrayFoto2;
+        public byte[] ArrayFoto3;
+        public byte[] ArrayFoto4;
+        public byte[] ArrayFoto5;
+        public byte[] ArrayFoto6;
+        public byte[] ArrayFoto7;
+
+        // ImageSources
+        private ImageSource _imageSource0;
+        private ImageSource _imageSource1;
+        private ImageSource _imageSource2;
+        private ImageSource _imageSource3;
+        private ImageSource _imageSource4;
+        private ImageSource _imageSource5;
+        private ImageSource _imageSource6;
+        private ImageSource _imageSource7;
+
+        public ImageSource Image0 { get => _imageSource0; set { _imageSource0 = value; OnPropertyChanged(nameof(Image0)); } }
+        public ImageSource Image1 { get => _imageSource1; set { _imageSource1 = value; OnPropertyChanged(nameof(Image1)); } }
+        public ImageSource Image2 { get => _imageSource2; set { _imageSource2 = value; OnPropertyChanged(nameof(Image2)); } }
+        public ImageSource Image3 { get => _imageSource3; set { _imageSource3 = value; OnPropertyChanged(nameof(Image3)); } }
+        public ImageSource Image4 { get => _imageSource4; set { _imageSource4 = value; OnPropertyChanged(nameof(Image4)); } }
+        public ImageSource Image5 { get => _imageSource5; set { _imageSource5 = value; OnPropertyChanged(nameof(Image5)); } }
+        public ImageSource Image6 { get => _imageSource6; set { _imageSource6 = value; OnPropertyChanged(nameof(Image6)); } }
+        public ImageSource Image7 { get => _imageSource7; set { _imageSource7 = value; OnPropertyChanged(nameof(Image7)); } }
+
+        public CediAgregarEvidenciaViewModel(long vehiculoDespachadoId)
+        {
+            _vehiculoDespachadoId = vehiculoDespachadoId;
+
+            TapCommand = new Command(OnTapped);
+            GrabarCommand = new Command(async () => await Grabar());
+            CerrarCommand = new Command(async () => await Cerrar());
+
+            InicializarImagenes();
+        }
+
+        private void InicializarImagenes()
+        {
+            var icon = ImageSource.FromFile("icon.png");
+            Image0 = Image1 = Image2 = Image3 = Image4 = Image5 = Image6 = Image7 = icon;
+        }
+
+        private async void OnTapped(object s)
+        {
+            string action = await Application.Current.MainPage.DisplayActionSheet(
+                "Opciones", "Cancelar", null, "Tomar Foto", "Eliminar Foto");
+
+            if (action == "Tomar Foto")
+            {
+                await Camara(1, s);
+            }
+            else if (action == "Subir Foto")
+            {
+                await Camara(2, s);
+            }
+            else if (action == "Eliminar Foto")
+            {
+                EliminarFoto(s.ToString());
+            }
+        }
+
+        private void EliminarFoto(string idx)
+        {
+            var icon = ImageSource.FromFile("icon.png");
+            switch (idx)
+            {
+                case "0": Image0 = icon; ArrayFoto0 = null; break;
+                case "1": Image1 = icon; ArrayFoto1 = null; break;
+                case "2": Image2 = icon; ArrayFoto2 = null; break;
+                case "3": Image3 = icon; ArrayFoto3 = null; break;
+                case "4": Image4 = icon; ArrayFoto4 = null; break;
+                case "5": Image5 = icon; ArrayFoto5 = null; break;
+                case "6": Image6 = icon; ArrayFoto6 = null; break;
+                case "7": Image7 = icon; ArrayFoto7 = null; break;
+            }
+        }
+
+        private async Task Camara(int accion, object imageControl)
+        {
+            try
+            {
+                await CrossMedia.Current.Initialize();
+                MediaFile file = null;
+
+                if (!CrossMedia.Current.IsCameraAvailable || !CrossMedia.Current.IsTakePhotoSupported)
+                {
+                    await Application.Current.MainPage.DisplayAlert("Cámara no disponible", "Verifique su dispositivo", "Cerrar");
+                    return;
+                }
+
+                if (accion == 1) // Tomar Foto
+                {
+                    //file = await CrossMedia.Current.TakePhotoAsync(new StoreCameraMediaOptions
+                    //{
+                    //    PhotoSize = PhotoSize.Custom,
+                    //    CustomPhotoSize = 60
+                    //});
+
+                    file = await CrossMedia.Current.TakePhotoAsync(
+                        new StoreCameraMediaOptions
+                        {
+                            SaveToAlbum = true,
+                            PhotoSize = PhotoSize.Small
+                        });
+                }
+                else if (accion == 2) // Subir Foto
+                {
+                    file = await CrossMedia.Current.PickPhotoAsync(new PickMediaOptions
+                    {
+                        PhotoSize = PhotoSize.Custom,
+                        CustomPhotoSize = 60
+                    });
+                }
+
+                if (file == null) return;
+
+                byte[] arrayFoto;
+                using (var ms = new MemoryStream())
+                {
+                    file.GetStream().CopyTo(ms);
+                    arrayFoto = ms.ToArray();
+                }
+
+                ImageSource fotoSource = ImageSource.FromStream(() => new MemoryStream(arrayFoto));
+                string idx = imageControl.ToString();
+
+                switch (idx)
+                {
+                    case "0": Image0 = fotoSource; ArrayFoto0 = arrayFoto; break;
+                    case "1": Image1 = fotoSource; ArrayFoto1 = arrayFoto; break;
+                    case "2": Image2 = fotoSource; ArrayFoto2 = arrayFoto; break;
+                    case "3": Image3 = fotoSource; ArrayFoto3 = arrayFoto; break;
+                    case "4": Image4 = fotoSource; ArrayFoto4 = arrayFoto; break;
+                    case "5": Image5 = fotoSource; ArrayFoto5 = arrayFoto; break;
+                    case "6": Image6 = fotoSource; ArrayFoto6 = arrayFoto; break;
+                    case "7": Image7 = fotoSource; ArrayFoto7 = arrayFoto; break;
+                }
+            }
+            catch (Exception ex)
+            {
+                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "Cerrar");
+            }
+        }
+
+        private async Task Grabar()
+        {
+            if (string.IsNullOrWhiteSpace(Observacion))
+            {
+                await Application.Current.MainPage.DisplayAlert("Error", "Debe ingresar una observación.", "OK");
+                return;
+            }
+
+            UserDialogs.Instance.ShowLoading("Enviando...");
+
+            try
+            {
+                string usuario = App.Current.Properties["Username"]?.ToString() ?? "sistema";
+
+                var request = new ParametroCediCrearEvidenciaEntrega
+                {
+                    VehiculoDespachadoID = _vehiculoDespachadoId,
+                    Observacion = this.Observacion,
+                    Usuario = usuario,
+                    Fotos = new List<CediEvidenciaEntregaFoto>()
+                };
+
+                var fotos = new[]
+                {
+                    ArrayFoto0, ArrayFoto1, ArrayFoto2, ArrayFoto3,
+                    ArrayFoto4, ArrayFoto5, ArrayFoto6, ArrayFoto7
+                };
+
+                foreach (var foto in fotos)
+                {
+                    if (foto != null && foto.Length > 0)
+                    {
+                        request.Fotos.Add(new CediEvidenciaEntregaFoto { ArrayFoto = foto });
+                    }
+                }
+
+
+
+                var response = await ServiceCedi.RegistraEvidenciaEntrega(request);
+
+                if (response?.Resultado?.Respuesta == true)
+                {
+                    await Application.Current.MainPage.DisplayAlert("Éxito", "Evidencia registrada correctamente.", "OK");
+                    
+                    MessagingCenter.Send(this, "EvidenciaGrabada");
+
+                    await Cerrar();
+                }
+                else
+                {
+                    await Application.Current.MainPage.DisplayAlert(
+                        "Error",
+                        string.Join("\n", response?.Resultado?.Mensajes ?? new List<string> { "Error desconocido" }),
+                        "OK");
+                }
+            }
+            catch (Exception ex)
+            {
+                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+            }
+            finally
+            {
+                UserDialogs.Instance.HideLoading();
+            }
+        }
+
+        private async Task Cerrar()
+        {
+            await Application.Current.MainPage.Navigation.PopModalAsync();
+        }
+    }
+}

--- a/BRBKApp/ViewModels/CediTarjaConsultaDetailViewModel.cs
+++ b/BRBKApp/ViewModels/CediTarjaConsultaDetailViewModel.cs
@@ -266,7 +266,7 @@ namespace BRBKApp.ViewModels
 
             _ = InitializeAsync();
 
-            MessagingCenter.Subscribe<VHSAgregarEvidenciaEntregaViewModel>(this, "EvidenciaGrabada", (sender) =>
+            MessagingCenter.Subscribe<CediAgregarEvidenciaViewModel>(this, "EvidenciaGrabada", (sender) =>
             {
                 PuedeDespachar = false;
             });
@@ -598,7 +598,7 @@ namespace BRBKApp.ViewModels
         {
             if (_entry != null && _entry.VehiculoDespachadoID > 0)
             {
-                await Application.Current.MainPage.Navigation.PushModalAsync(new VHSAgregarEvidenciaEntrega(_entry.VehiculoDespachadoID));
+                await Application.Current.MainPage.Navigation.PushModalAsync(new CediAgregarEvidenciaEntrega(_entry.VehiculoDespachadoID));
             }
             else
             {

--- a/BRBKApp/Views/CediAgregarEvidenciaEntrega.xaml
+++ b/BRBKApp/Views/CediAgregarEvidenciaEntrega.xaml
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             BackgroundColor="#80000000"
+             x:Class="BRBKApp.Views.CediAgregarEvidenciaEntrega"
+             Padding="0">
+
+    <ContentPage.Content>
+        <Grid VerticalOptions="CenterAndExpand" HorizontalOptions="CenterAndExpand">
+            <Frame BackgroundColor="White"
+                   CornerRadius="20"
+                   Padding="20"
+                   HasShadow="True"
+                   WidthRequest="350"
+                   VerticalOptions="Center"
+                   HorizontalOptions="Center">
+                <StackLayout Spacing="15">
+                    <Label Text="Evidencia de Entrega"
+                           FontSize="20"
+                           HorizontalOptions="Center"/>
+
+                    <Editor Placeholder="Observación"
+                            Text="{Binding Observacion}"
+                            HeightRequest="80"/>
+
+                    <Label Text="Fotos de Evidencia" />
+
+                    <!-- Primera fila de 4 fotos -->
+                    <FlexLayout Direction="Row" JustifyContent="SpaceAround" AlignItems="Start">
+                        <Frame BorderColor="LightGray" Padding="0" Margin="5">
+                            <Image Source="{Binding Image0}"
+                                   HeightRequest="100"
+                                   WidthRequest="100">
+                                <Image.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding TapCommand}" CommandParameter="0"/>
+                                </Image.GestureRecognizers>
+                            </Image>
+                        </Frame>
+                        <Frame BorderColor="LightGray" Padding="0" Margin="5">
+                            <Image Source="{Binding Image1}"
+                                   HeightRequest="100"
+                                   WidthRequest="100">
+                                <Image.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding TapCommand}" CommandParameter="1"/>
+                                </Image.GestureRecognizers>
+                            </Image>
+                        </Frame>
+                        <Frame BorderColor="LightGray" Padding="0" Margin="5">
+                            <Image Source="{Binding Image2}"
+                                   HeightRequest="100"
+                                   WidthRequest="100">
+                                <Image.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding TapCommand}" CommandParameter="2"/>
+                                </Image.GestureRecognizers>
+                            </Image>
+                        </Frame>
+                        <Frame BorderColor="LightGray" Padding="0" Margin="5">
+                            <Image Source="{Binding Image3}"
+                                   HeightRequest="100"
+                                   WidthRequest="100">
+                                <Image.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding TapCommand}" CommandParameter="3"/>
+                                </Image.GestureRecognizers>
+                            </Image>
+                        </Frame>
+                    </FlexLayout>
+
+                    <!-- Segunda fila de 4 fotos -->
+                    <FlexLayout Direction="Row" JustifyContent="SpaceAround" AlignItems="Start">
+                        <Frame BorderColor="LightGray" Padding="0" Margin="5">
+                            <Image Source="{Binding Image4}"
+                                   HeightRequest="100"
+                                   WidthRequest="100">
+                                <Image.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding TapCommand}" CommandParameter="4"/>
+                                </Image.GestureRecognizers>
+                            </Image>
+                        </Frame>
+                        <Frame BorderColor="LightGray" Padding="0" Margin="5">
+                            <Image Source="{Binding Image5}"
+                                   HeightRequest="100"
+                                   WidthRequest="100">
+                                <Image.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding TapCommand}" CommandParameter="5"/>
+                                </Image.GestureRecognizers>
+                            </Image>
+                        </Frame>
+                        <Frame BorderColor="LightGray" Padding="0" Margin="5">
+                            <Image Source="{Binding Image6}"
+                                   HeightRequest="100"
+                                   WidthRequest="100">
+                                <Image.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding TapCommand}" CommandParameter="6"/>
+                                </Image.GestureRecognizers>
+                            </Image>
+                        </Frame>
+                        <Frame BorderColor="LightGray" Padding="0" Margin="5">
+                            <Image Source="{Binding Image7}"
+                                   HeightRequest="100"
+                                   WidthRequest="100">
+                                <Image.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding TapCommand}" CommandParameter="7"/>
+                                </Image.GestureRecognizers>
+                            </Image>
+                        </Frame>
+                    </FlexLayout>
+
+                    <StackLayout Orientation="Horizontal"
+                                 HorizontalOptions="Center"
+                                 Spacing="10">
+                        <Button Text="Grabar Evidencia"
+                                Command="{Binding GrabarCommand}"
+                                BackgroundColor="#4CAF50"
+                                TextColor="White"
+                                WidthRequest="150"/>
+                        <Button Text="Cerrar"
+                                Command="{Binding CerrarCommand}"
+                                BackgroundColor="Gray"
+                                TextColor="White"
+                                WidthRequest="100"/>
+                    </StackLayout>
+                </StackLayout>
+            </Frame>
+        </Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/BRBKApp/Views/CediAgregarEvidenciaEntrega.xaml.cs
+++ b/BRBKApp/Views/CediAgregarEvidenciaEntrega.xaml.cs
@@ -1,0 +1,22 @@
+﻿using BRBKApp.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace BRBKApp.Views
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class CediAgregarEvidenciaEntrega : ContentPage
+    {
+        public CediAgregarEvidenciaEntrega(long vehiculoDespachadoId)
+        {
+            InitializeComponent();
+            BindingContext = new CediAgregarEvidenciaViewModel(vehiculoDespachadoId);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `CediAgregarEvidenciaViewModel` for CEDI evidence capture
- hook `CediTarjaConsultaDetailViewModel` to new view model via `MessagingCenter`
- support CEDI evidence registration in `ServiceCedi` and `Datos`
- introduce `ParametroCediCrearEvidenciaEntrega`
- create dedicated CEDI evidence page and keep VHS page intact

## Testing
- `dotnet build BRBKApp.sln -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871261879d48330821b236a9af3404b